### PR TITLE
Update AWS Consumer

### DIFF
--- a/loafer/aws/consumer.py
+++ b/loafer/aws/consumer.py
@@ -15,15 +15,17 @@ logger = logging.getLogger(__name__)
 
 class Consumer(object):
 
-    def __init__(self, source, options=None, loop=None):
+    def __init__(self, source, endpoint_url=None, use_ssl=True, options=None, loop=None):
         self.source = source
+        self.endpoint_url = endpoint_url
+        self.use_ssl = use_ssl
         self._loop = loop or asyncio.get_event_loop()
         self._client = None
         self._consumer_options = options
 
     def get_client(self):
         if self._client is None:
-            self._client = boto3.client('sqs')
+            self._client = boto3.client('sqs', endpoint_url=self.endpoint_url, use_ssl=self.use_ssl)
         return self._client
 
     async def get_queue_url(self):

--- a/loafer/route.py
+++ b/loafer/route.py
@@ -1,7 +1,7 @@
 import asyncio
 import logging
 
-from .aws.message_translator import SQSMessageTranslator
+from .aws.message_translator import SNSMessageTranslator
 
 logger = logging.getLogger(__name__)
 
@@ -14,7 +14,7 @@ class Route(object):
         self.message_handler_name = type(message_handler).__name__
 
         if message_translator is None:
-            self.message_translator = SQSMessageTranslator()
+            self.message_translator = SNSMessageTranslator()
         else:
             self.message_translator = message_translator
 


### PR DESCRIPTION
Esse PR atualiza o AWS Consumer para permitir o uso com o https://github.com/p4tin/GoAws, aproveitei e alterei o message translator padrão para SNSMessageTranslator.

Eis um exemplo de uso com o GoAws:

```python
from loafer.manager import LoaferManager
from loafer.route import Route
from loafer.aws.consumer import Consumer as AWSConsumer


def handle(message):
    print(message)

queue_name = 'local-queue1'
consumer = AWSConsumer(queue_name, options={'WaitTimeSeconds': 5, 'MaxNumberOfMessages': 5},
                       endpoint_url='http://localhost:4100', use_ssl=False)
loafer = LoaferManager(queue_name, consumers=[consumer])
loafer.routes.append(Route(source=queue_name, message_handler=handle))
loafer.start()
```